### PR TITLE
Switch from exec to docker deployments

### DIFF
--- a/dp-hierarchy-builder.nomad
+++ b/dp-hierarchy-builder.nomad
@@ -28,11 +28,7 @@ job "dp-hierarchy-builder" {
     }
 
     task "dp-hierarchy-builder" {
-      driver = "exec"
-
-      artifact {
-        source = "s3::https://s3-eu-west-1.amazonaws.com/{{BUILD_BUCKET}}/dp-hierarchy-builder/{{REVISION}}.tar.gz"
-      }
+      driver = "docker"
 
       artifact {
         source = "s3::https://s3-eu-west-1.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-hierarchy-builder/{{REVISION}}.tar.gz"
@@ -40,9 +36,14 @@ job "dp-hierarchy-builder" {
 
       config {
         command = "${NOMAD_TASK_DIR}/start-task"
-        args    = [
-          "${NOMAD_TASK_DIR}/dp-hierarchy-builder",
-        ]
+
+        args = ["./dp-hierarchy-builder"]
+
+        image = "{{ECR_URL}}:concourse-{{REVISION}}"
+
+        port_map {
+          http = "${NOMAD_PORT_http}"
+        }
       }
 
       service {


### PR DESCRIPTION
### What

The exec driver builds linux containers in place and is very slow and
resource intensive.  Moving to the docker driver not only resolves this
issue it also adds consistency and therefore simplifies our ecosystem.

### How to review

Ensure the plan is valid.

### Who can review

Anyone but me.
