### PR TITLE
Restructure import scripts to make room for gremlin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ instance-clean:
 	sed "s/12345/$(INSTANCE_ID)/g" < cmd/builder/build-delete.cypher | cypher-shell
 generate-full:
 	HUMAN_LOG=1 go run -race cmd/hierarchy-transformer/main.go
+generate-full-import:
+	HUMAN_LOG=1 go run -race cmd/hierarchy-transformer/main.go -file import-scripts/$(CODE_LIST).csv -cypher import-scripts/cypher/$(CODE_LIST).cypher -gremlin import-scripts/gremlin/$(CODE_LIST).grm
 generate-full-from-v4:
 	HUMAN_LOG=1 go run -race "$(V4_TRANSFORMER_DIR)/main.go"
 generate-full-from-geography:

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The hierarchy builder is a service that forms part of the dataset import process
 
 Import the CPIH full hierarchy:
 
-`cypher-shell < cmd/v4-transformer/output/cpih/hierarchy-cpih.cypher`
+`cypher-shell < import-scripts/cypher/cpih1dim1aggid.cypher`
 
 Import the mid-year-pop-est full hierarchy:
 
-`cypher-shell < cmd/hierarchy-transformer/output/midYearPopEst/hierarchy.cypher`
+`cypher-shell < import-scripts/cypher/mid-year-pop-geography.cypher`
 
 You can use additional flags if running against an environment other than localhost:
 
@@ -52,10 +52,10 @@ Plus the graph database vars from [dp-graph](https://github.com/ONSdigital/dp-gr
 
 There are a number of utility applications for manual tasks (found under the cmd directory):
 
-* v4-transformer - take a V4 file and create a full hierarchy input file / cypher script
-* geography-transformer - take a geography input CSV file and output a full hierarchy input file / cypher script
-* hierarchy-transformer - take a hierarchy input CSV file and generate cypher script
 * builder - builds an instance hierarchy from a full hierarchy
+* v4-transformer - take a V4 file and create a full hierarchy input file / cypher/gremlin scripts for codes following the 1.2.3 format
+* geography-transformer - take a geography input CSV file and output a full hierarchy input file / cypher/gremlin scripts
+* hierarchy-transformer - take a hierarchy input CSV file, containing codes, labels and parent codes and generate cypher/gremlin scripts
 
 #### Manually building instance hierarchies
 
@@ -71,17 +71,10 @@ If running one of the above commands against an environment, you can specify the
 
 `--neo-url="bolt://USER:PASSWORD@localhost:7687"`
 
-#### transform a hierarchy input file to a cypher script (set FILE as required input file)
+#### Transformers
 
-`make FILE=./cmd/hierarchy-transformer/hierarchy.csv generate-full`
-
-output is written to `./cmd/hierarchy-transformer/output`
-
-#### transform a geography input file to a hierarchy input file / cypher script
-
-`make FILE=./cmd/geography-transformer/WD16_LAD16_CTY16_OTH_UK_LU.csv  generate-full-from-geography `
-
-output is written to ``./cmd/geography-transformer/output`
+Transformers allow the conversion of CSV files into the cypher/gremlin scripts needed to load the full (generic) hierarchy into a graph database.
+See [TRANSFORMERS](TRANSFORMERS.md) for details.
 
 ### Contributing
 

--- a/TRANSFORMERS.md
+++ b/TRANSFORMERS.md
@@ -1,0 +1,36 @@
+Transformers and Importing
+================
+
+Before the hierarchy builder service can be used meaningfully, the database must be prepopulated with full (generic) hierarchies to build from.
+
+
+### Transformers
+
+There are 2 primary ways to generate hierarchy import scripts, and they each rely on a CSV input
+
+#### Using a generic hierarchy input file
+
+A CSV of 4 columns is needed: `codelist, code, label, parentcode`. While the names of these columns is not important, the order is!
+Ideally, this CSV should be placed at `import-scripts/<codelist>.csv`, as recommended below. This will allow for the following make target to be used:
+
+`CODE_LIST=<codelist> make generate-full-import`
+where `<codelist>` is replaced by the list you're aiming to create an import file for.
+
+The result should be the creation of the relevant files in the `cypher` and `gremlin` subdirectories of `import-scripts`
+
+#### Using a geography input file
+
+The geography team publish hierarchies as part of their regular process. This includes an established CSV format.
+When working with these CSVs, run the following command, replacing the CSV file name as needed.
+
+`make FILE=./cmd/geography-transformer/WD16_LAD16_CTY16_OTH_UK_LU.csv  generate-full-from-geography `
+
+By default, output is written to ``./cmd/geography-transformer/output`, but you should ensure your outputs are redirected or copied
+to the relevant `import-scripts` locations along with you input file.
+
+### Import files
+
+In order to keep track of how scripts have been generated, their inputs should be stored as CSVs in [import-scripts](./import-scripts)
+
+The `import-scripts` directory contains further subdirectories for `cypher` and `gremlin` outputs. For consistency,
+all of these files should be named for the codelist/hierarchy ID they relate to.


### PR DESCRIPTION
### What

Relocated existing cypher-scripts under a common import-scripts
Create the first gremlin scripts
Backed up some input files, so we know where scripts are coming from
Updated makefile to include a target to write directly to the new location
Fixed gremlin script generation to work on a neptune implementation

### How to review

check documentation is clear, and allows for the generation of scripts which validly import to both databases

### Who can review

anyone