### PR TITLE
Upgrade dp-graph to v2.0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-hierarchy-builder
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-graph/v2 v2.0.9
+	github.com/ONSdigital/dp-graph/v2 v2.0.11
 	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/dp-import v0.0.0-20180202121531-d3cc28e452c3
 	github.com/ONSdigital/dp-kafka v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ONSdigital/dp-graph/v2 v2.0.9 h1:LqmwUthr2dOYqjwMVmMwArr6HzPUSvl02fBO52acn9Y=
-github.com/ONSdigital/dp-graph/v2 v2.0.9/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
+github.com/ONSdigital/dp-graph/v2 v2.0.11 h1:m2bfLae4DUZKurDP5ZGopO5n1zeNjYCT64S2y7d/yyU=
+github.com/ONSdigital/dp-graph/v2 v2.0.11/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.3 h1:wNA34U3uPD5t1SE8P3cbGqNZP4CUjyJFbSugPYgrBG0=


### PR DESCRIPTION
### What
Upgrade dp-graph to v2.0.11
- contains a fix for marking hierarchy nodes to remain when building hierarchies in Neptune

### How to review
Sanity check

### Who can review
Anyone
