### PR TITLE
Update gremlin-import.sh to use a secure Neptune connection

### DIFF
--- a/gremlin-import.sh
+++ b/gremlin-import.sh
@@ -8,7 +8,7 @@ for input; do
 done
 
 {
-	echo :remote connect tinkerpop.server conf/remote.yaml
+	echo :remote connect tinkerpop.server conf/remote-secure.yaml
 	echo :remote console
 	for input; do
 		echo :load $PWD/$input


### PR DESCRIPTION
### What

- Update gremlin-import.sh to use a secure Neptune connection
The recently updated version of AWS Neptune requires all connections to be secure.

### How to review
Sanity check

The updated line should reflect what is documented in the neptune guide https://github.com/ONSdigital/dp/blob/main/guides/NEPTUNE.md#gremlin-console, using `conf/remote-secure.yaml` instead of conf/remote.yaml

### Who can review
Anyone