### PR TITLE
update dp-graph dependency to use the version with the code node quer…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.33.5 // indirect
-	github.com/ONSdigital/dp-graph/v2 v2.11.2
+	github.com/ONSdigital/dp-graph/v2 v2.12.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-import v0.0.0-20180202121531-d3cc28e452c3
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.33.5 h1:OorHPAkcf0L1TT4e9Gn68Q2ouuqkN4ieWgB2JmXD3YI=
 github.com/ONSdigital/dp-api-clients-go v1.33.5/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.11.2 h1:F2M2emGYKi5gp0DglyYjm1uTdY4b7sxL2vJ8CL6Kprs=
-github.com/ONSdigital/dp-graph/v2 v2.11.2/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
+github.com/ONSdigital/dp-graph/v2 v2.12.1 h1:KkIKJMt1BBCjlu/tjPXU47XKzMVgDY2Tel4ZbhaFIgk=
+github.com/ONSdigital/dp-graph/v2 v2.12.1/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=


### PR DESCRIPTION
### What

Update `dp-graph` dependency to use the version with the code node query bug fix.

This fixes the bug where hierarchy builds for codes that are used by multiple code lists failed to copy the order from the generic hierarchy.

### How to review

- Make sure that go.mod is updated with dp-graph version 2.12.1

### Who can review

anyone