### PR TITLE
Fix/dp kafka v2.4.3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 
 	cfg := &Config{
 		BindAddr:                   ":22700",
-		KafkaAddr:                  []string{"localhost:9092"},
+		KafkaAddr:                  []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		KafkaVersion:               "1.0.2",
 		KafkaOffsetOldest:          true,
 		ConsumerTopic:              "data-import-complete",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestSpec(t *testing.T) {
 
 			Convey("The values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, ":22700")
-				So(cfg.KafkaAddr, ShouldResemble, []string{"localhost:9092"})
+				So(cfg.KafkaAddr, ShouldResemble, []string{"localhost:9092", "localhost:9093", "localhost:9094"})
 				So(cfg.KafkaVersion, ShouldEqual, "1.0.2")
 				So(cfg.KafkaOffsetOldest, ShouldBeTrue)
 				So(cfg.KafkaSecProtocol, ShouldEqual, "")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-graph/v2 v2.14.0
 	github.com/ONSdigital/dp-healthcheck v1.1.1
 	github.com/ONSdigital/dp-import v1.2.1
-	github.com/ONSdigital/dp-kafka/v2 v2.4.1
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-reporter-client v1.1.0
 	github.com/ONSdigital/go-ns v0.0.0-20210831102424-ebdecc20fe9e // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/ONSdigital/dp-import v1.2.1 h1:IySfrNsrsWaqFAVgZSaOEaE5StVUJ1TJIZgVAF
 github.com/ONSdigital/dp-import v1.2.1/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
 github.com/ONSdigital/dp-kafka/v2 v2.2.0/go.mod h1:lFw9GGYpW8N6dG7g2wLQgCJL9vpo17RvOzCsdMRCapQ=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1 h1:e4nTpfsqb/gRRF3ZgstZ8mEjONvt+QPoWKbZoRg5dU8=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone